### PR TITLE
HyP3lib and other updates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -12,17 +12,17 @@ or pull requests
 ### Developer checklist
 
 - [ ] Assigned a reviewer
-  <!-- NOTE: Pull requests should only be opened for merges to protected branches (required) and any 
+  <!-- NOTE: Pull requests should only be opened for merges to protected branches (required) and any
    changes which you'd like reviewed. Do not open a pull request to update a feature or personal
    branch -- simply merge with `git`.
    -->
 - [ ] Indicated the level of changes to this package by affixing one of these labels:
   * ~"major" -- Major changes to the API that may break current workflows
-  * ~"minor" -- Minor changes to the API that do not break current workflows 
+  * ~"minor" -- Minor changes to the API that do not break current workflows
   * ~"patch" -- Patches and bugfixes for the current version that do not break current workflows
-  * ~"bumpless" -- Changes to documentation, CI/CD pipelines, etc. that don't affect the software's version 
+  * ~"bumpless" -- Changes to documentation, CI/CD pipelines, etc. that don't affect the software's version
 
-- [ ] (If applicable) Updated the dependencies and indicated any downstream changes that are required 
+- [ ] (If applicable) Updated the dependencies and indicated any downstream changes that are required
 
 - [ ] Updated the CHANGELOG.md
 - [ ] Added/updated documentation for these changes
@@ -30,7 +30,6 @@ or pull requests
 
 ### Reviewer checklist
 
-- [ ] Are all the Checks passing?
 - [ ] Have all dependencies been updated and required changes merged downstream?
 - [ ] Is the level of changes labeled appropriately?
 - [ ] Are all the changes described appropriately in the changelog?

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,11 @@ jobs:
           token: ${{ secrets.TOOLS_BOT_PAK }}
 
       - name: Create Release
-        uses: actions/create-release@v1
+        uses: docker://antonyurchenko/git-release:latest
         env:
           GITHUB_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: HyP3 InSAR ISCE ${{ github.ref }}
+          ALLOW_TAG_PREFIX: "true"
+          RELEASE_NAME_PREFIX: HyP3 InSAR ISCE
 
       - name: Attempt fast-forward develop from master
         run: |
@@ -41,4 +40,5 @@ jobs:
           pr_assignee: ${{ github.actor }}
           pr_label: tools-bot
           pr_draft: false
+          pr_allow_empty: true
           github_token: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -29,7 +29,6 @@ jobs:
           python-version: 3.7
           activate-environment: hyp3-insar-isce
           environment-file: conda-env.yml
-          channels: conda-forge, nodefaults
 
       - name: Pytest in conda environment
         shell: bash -l {0}

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Pytest in conda environment
         shell: bash -l {0}
         run: |
-          python -m pip install .
+          python -m pip install .[develop]
           pytest --cov=hyp3_insar_isce
 
       - name: Safety analysis of conda environment

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,5 +58,5 @@ RUN python -m pip install --no-cache-dir hyp3_insar_isce${SDIST_SPEC} \
     --trusted-host "${S3_PYPI_HOST}" \
     --extra-index-url "http://${S3_PYPI_HOST}"
 
-ENTRYPOINT ["conda", "run", "-n", "hyp3-insar-isce", "proc_insar_isce.py"]
+ENTRYPOINT ["conda", "run", "-n", "hyp3-insar-isce", "hyp3_insar_isce"]
 CMD ["-h"]

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -53,5 +53,5 @@ dependencies:
     # For running
     - --trusted-host hyp3-pypi.s3-website-us-east-1.amazonaws.com
       --extra-index-url http://hyp3-pypi.s3-website-us-east-1.amazonaws.com
-    - hyp3lib
-    - hyp3proclib
+    - hyp3lib>=1.4.1,<2
+    - hyp3proclib>=1,<2

--- a/conda-env.yml
+++ b/conda-env.yml
@@ -41,6 +41,7 @@ dependencies:
   - scons
   - six
   - statsmodels
+  - urllib3
   - xorg-libxdmcp
   - xorg-libxft
   - xorg-libxmu

--- a/hyp3_insar_isce/__main__.py
+++ b/hyp3_insar_isce/__main__.py
@@ -3,6 +3,7 @@ import datetime
 import os
 import shutil
 
+from hyp3lib.metadata import add_esa_citation
 from hyp3proclib import (
     build_output_name_pair,
     earlier_granule_first,
@@ -18,7 +19,7 @@ from hyp3proclib import (
     zip_dir
 )
 from hyp3proclib.db import get_db_connection
-from hyp3proclib.file_system import add_citation, cleanup_workdir
+from hyp3proclib.file_system import cleanup_workdir
 from hyp3proclib.logger import log
 from hyp3proclib.proc_base import Processor
 
@@ -89,7 +90,7 @@ def process_insar(cfg, n):
             find_browses(cfg, out_path)
 
             cfg['attachment'] = find_phase_png(out_path)
-            add_citation(cfg, out_path)
+            add_esa_citation(g1, out_path)
             zip_dir(out_path, zip_file)
 
             cfg['final_product_size'] = [os.stat(zip_file).st_size, ]

--- a/hyp3_insar_isce/proc_all_s1_stack_isce.py
+++ b/hyp3_insar_isce/proc_all_s1_stack_isce.py
@@ -1,16 +1,14 @@
-#!/usr/bin/env python
 """Create All interferograms overlapping the ROI using ISCE"""
-
-from __future__ import print_function
 
 import argparse
 import os
 import sys
 
-from hyp3lib import __version__, getSubSwath
+from hyp3lib import getSubSwath
 from hyp3lib.file_subroutines import get_file_list
 from hyp3lib.file_subroutines import prepare_files
 
+from hyp3_insar_isce import __version__
 from hyp3_insar_isce.proc_s1_stack_isce import proc_s1_stack_isce
 
 
@@ -49,7 +47,7 @@ def main():
     parser.add_argument("east", help="Maximum longitude")
     parser.add_argument("-f", "--csv-file", help="list of files to download, in csv format")
     parser.add_argument("-d", "--dem", action="store_true", help="Use the ASF DEM heap instead of opentopo")
-    parser.add_argument('--version', action='version', version='hyp3_insar_isce {}'.format(__version__))
+    parser.add_argument('--version', action='version', version=f'hyp3_insar_isce {__version__}')
     args = parser.parse_args()
 
     proc_all_s1_stack_isce(args.south, args.north, args.west, args.east, csv_file=args.csv_file, dem=args.dem)

--- a/hyp3_insar_isce/proc_s1_isce.py
+++ b/hyp3_insar_isce/proc_s1_isce.py
@@ -122,20 +122,20 @@ def proc_s1_isce(ss, master, slave, gbb=None, xml=False, unwrap=False, dem=None)
     g1_orbit_file, _ = downloadSentinelOrbitFile(g1, directory=isce_dir)
     g2_orbit_file, _ = downloadSentinelOrbitFile(g2, directory=isce_dir)
 
-    create_isce_xml(g1, g2, g1_orbit_file, g2_orbit_file, options)
+    create_isce_xml(g1, g2, os.path.basename(g1_orbit_file), os.path.basename(g2_orbit_file), options)
 
     # Process through preprocess
-    # execute(f'cd {bname}/{ss} ; topsApp.py --end=preprocess')
+    # execute(f'cd {isce_dir} ; topsApp.py --end=preprocess')
 
-    # execute(f'cd {bname}/{ss} ; topsApp.py --start=computeBaselines --end=filter')
+    # execute(f'cd {isce_dir} ; topsApp.py --start=computeBaselines --end=filter')
 
     # if options['unwrap'] == True:
-    #     execute(f'cd {bname}/{ss} ; topsApp.py --dostep=unwrap')
+    #     execute(f'cd {isce_dir} ; topsApp.py --dostep=unwrap')
 
-    # execute(f'cd {bname}/{ss} ; topsApp.py --dostep=geocode')
+    # execute(f'cd {isce_dir} ; topsApp.py --dostep=geocode')
 
     if options['proc']:
-        execute(f'cd {bname}/{ss} ; topsApp.py')
+        execute(f'cd {isce_dir} ; topsApp.py')
 
 
 def main():

--- a/hyp3_insar_isce/proc_s1_isce.py
+++ b/hyp3_insar_isce/proc_s1_isce.py
@@ -124,7 +124,6 @@ def proc_s1_isce(ss, master, slave, gbb=None, xml=False, unwrap=False, dem=None)
 
     create_isce_xml(g1, g2, os.path.basename(g1_orbit_file), os.path.basename(g2_orbit_file), options)
 
-    # Process through preprocess
     # execute(f'cd {isce_dir} ; topsApp.py --end=preprocess')
 
     # execute(f'cd {isce_dir} ; topsApp.py --start=computeBaselines --end=filter')

--- a/hyp3_insar_isce/proc_s1_stack_isce.py
+++ b/hyp3_insar_isce/proc_s1_stack_isce.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
 """Create a stack of interferograms using ISCE software"""
-
-from __future__ import print_function
 
 import argparse
 import os
@@ -9,13 +6,14 @@ import re
 import sys
 from shutil import copyfile
 
-from hyp3lib import __version__, file_subroutines, getSubSwath
+from hyp3lib import file_subroutines, getSubSwath
 from hyp3lib import saa_func_lib as saa
 from hyp3lib.execute import execute
 from hyp3lib.get_dem import get_ISCE_dem
 from hyp3lib.iscegeo2geotif import convert_files
 from lxml import etree
 
+from hyp3_insar_isce import __version__
 from hyp3_insar_isce.proc_s1_isce import proc_s1_isce
 
 
@@ -238,7 +236,7 @@ def main():
                             "bounding box from first image")
     group.add_argument("-s", "--ss",
                        help="Set the subswath to process. If ROI is specified, calculate subswath")
-    parser.add_argument('--version', action='version', version='hyp3_insar_isce {}'.format(__version__))
+    parser.add_argument('--version', action='version', version=f'hyp3_insar_isce {__version__}')
     args = parser.parse_args()
 
     proc_s1_stack_isce(csv_file=args.csv_file, dem=args.dem, roi=args.roi, ss=args.ss)

--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
     python_requires='~=3.7',
 
     install_requires=[
-        'hyp3lib',
-        'hyp3proclib',
+        'hyp3lib>=1.4.1,<2',
+        'hyp3proclib~=1.0',
         'importlib_metadata',
         'lxml',
     ],
@@ -49,7 +49,7 @@ setup(
     packages=find_packages(),
 
     entry_points={'console_scripts': [
-        'proc_insar_isce.py = hyp3_insar_isce.__main__:main',
+        'hyp3_insar_isce = hyp3_insar_isce.__main__:main',
         'procAllS1StackISCE.py = hyp3_insar_isce.proc_all_s1_stack_isce:main',
         'procS1ISCE.py = hyp3_insar_isce.proc_s1_isce:main',
         'procS1StackISCE.py = hyp3_insar_isce.proc_s1_stack_isce:main',

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,5 +1,5 @@
 def test_proc_insar_isce(script_runner):
-    ret = script_runner.run('proc_insar_isce.py', '-h')
+    ret = script_runner.run('hyp3_insar_isce', '-h')
     assert ret.success
 
 


### PR DESCRIPTION
* Update's `hyp3lib` to `>=1.4.1`
  * **Fixes** bug with outdated pyproj syntax
  * Drops overviews from GeoTIFFs because they are packaged inside zip files and can't be utilized (should see an ~25% size reduction)
  * Drops low-res browse images
* Cleans up the creation of the ISCE processing directory and subsequent calls
  * Removes unecessary `isce_pre_process`, `isce_process`, `prep_dir_isce` and `create_base_dir` functions
* Updates to the github workflow and community files
* Main v1 entrypoint has been renamed from `hyp3_proc_pair.py` to `hyp3_insar_isce` to be in-line with other containerized processes
* hyp3-insar-isce entrypoints now report the hyp3-insar-isce version instead of the hyp3-lib version